### PR TITLE
Fix edit.py for special $EDITOR variable

### DIFF
--- a/kb/commands/edit.py
+++ b/kb/commands/edit.py
@@ -57,7 +57,7 @@ def edit(args: Dict[str, str], config: Dict[str, str]):
         if len(artifacts) == 1:
             artifact = artifacts.pop()
             category_path = Path(config["PATH_KB_DATA"], artifact.category)
-            call([config["EDITOR"], Path(category_path, artifact.title)])
+            call([config["EDITOR"], Path(category_path, artifact.title)], shell=True)
         elif len(artifacts) > 1:
             print(
                 "There is more than one artifact with that title, please specify a category")


### PR DESCRIPTION
Add shell=True to subprocess.call() in kb/commands/edit.py

What this PR fixes:

`edit` sub command error if $EDITOR is set to "vim -u <path-to-vimrc>".