### PR TITLE
Update CI, add codespell and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,31 @@
+os: linux
+dist: focal
 language: python            # this works for Linux but is an error on macOS or Windows
-matrix:
+jobs:
   include:
-    - name: "Python on Linux"
-      python: 3.8           
-    - name: "Python 3.7 on macOS"
+    - name: "Python 3.8.3 on Linux"
+      python: 3.8
+    - name: "Python 3.8.5 on macOS"
       os: osx
-      osx_image: xcode11    # Python 3.7.2 running on macOS 10.14.3
+      osx_image: xcode12    # Python 3.8.2 running on macOS 10.15.6
       language: shell       # 'language: python' is an error on Travis CI macOS
-      # python: 3.7         # 'python:' is ignored on Travis CI macOS
+      # python: 3.8         # 'python:' is ignored on Travis CI macOS
       before_install: python3 --version ; pip3 --version ; sw_vers
-    - name: "Python 3.7 on Windows"
+    - name: "Python 3.8.5 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows
-      # python: 3.7         # 'python:' is ignored on Travis CI Windows
-      env:  PATH=/c/Python37:/c/Python37/Scripts:$PATH
+      # python: 3.8         # 'python:' is ignored on Travis CI Windows
+      env:  PATH=/c/Python38:/c/Python38/Scripts:$PATH
       before_install:
-        - choco install python  --version 3.7 # this install takes at least 1 min 30 sec
-        - python --version
-        - python -m pip install --upgrade pip
+        - choco install python --version 3.8.5  # this install takes at least 1 min 30 sec
 
 install:
   - ./.travis/install.sh
 
 script:
+  - python --version
+  - codespell . --ignore-words-list=hist --quiet-level=2
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - pytest
 
 before_deploy:
@@ -30,11 +33,10 @@ before_deploy:
 
 deploy:
   provider: releases
-  api_key: $RELEASE_TOKEN
+  token: $RELEASE_TOKEN
   file_glob: true
   file: 
     - dist/kb_*
-  skip_cleanup: true
   on:
     tags: true
   name: $TRAVIS_TAG

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
-if [ $TRAVIS_OS_NAME = 'osx' ]; then
-    pip3 install --upgrade pip
-    pip3 install --upgrade setuptools
-    pip3 install -r requirements-dev.txt
-    pip3 install .
-    pip3 install --upgrade pyinstaller
-elif [ $TRAVIS_OS_NAME = 'windows' ]; then
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade setuptools
-    python -m pip install -r requirements-dev.txt
-    python -m pip install .
-    python -m pip install --upgrade pyinstaller
+if [ $TRAVIS_OS_NAME = 'windows' ]; then
+    PYTHON="py"
 else
-    pip install --upgrade pip
-    pip install --upgrade setuptools
-    pip install -r requirements-dev.txt
-    pip install .
-    pip install --upgrade pyinstaller
+    PYTHON="python3"
 fi
 
+$PYTHON -m pip install --upgrade pip setuptools
+$PYTHON -m pip install -r requirements-dev.txt
+$PYTHON -m pip install .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-pytest
+-r requirements.txt
+codespell
 coverage
+flake8
+pyinstaller
+pytest
 pytest-cov
-colored
-attrs
-attr
-toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+attr
+attrs
 colored
 toml
-attrs
-attr


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
* Update CI to Python 3.8 on Linux, macOS, and Window
* Unify requirements files, sort requirements to make it easier to spot duplicates when requirements grow.
* Add codespell and flake8
* Fix Travis CI build config issues

![Screenshot 2020-09-22 at 11 07 11](https://user-images.githubusercontent.com/3709715/93863527-e50edc00-fcc3-11ea-9a38-b65da9ed181a.png)

Does this close any currently open issues?
------------------------------------------
...


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ or https://bpaste.net and insert the link here.)

Any other comments?
-------------------
...

Where has this been tested?
---------------------------

**Operating System:** ...

**Platform:** ...

**Target Platform:** ...
