### PR TITLE
Fix bug --edit-content option throws UboundedLocalError with --id option

### DIFF
--- a/kb/cl_parser.py
+++ b/kb/cl_parser.py
@@ -323,10 +323,11 @@ def parse_args(args):
         type=str,
     )
     update_parser.add_argument(
-        "-x", "--edit-content",
+        "-x",
+        "--edit-content",
         help="Edit content of the artifact",
-        default=None,
-        type=str,
+        action="store_true",
+        dest="edit_content",
     )
 
     # delete parser

--- a/kb/commands/update.py
+++ b/kb/commands/update.py
@@ -98,6 +98,16 @@ def update(args: Dict[str, str], config: Dict[str, str]):
                 "There is more than one artifact with that title, please specify a category")
 
     if args["edit_content"]:
-        shell_cmd = shlex.split(
-            config["EDITOR"]) + [str(Path(category_path, artifact.title))]
+        if args["title"]:
+            shell_cmd = shlex.split(config["EDITOR"]) + [
+                str(Path(category_path, artifact.title))
+            ]
+        elif args["id"]:
+            shell_cmd = shlex.split(config["EDITOR"]) + [
+                str(
+                    Path(config["PATH_KB_DATA"])
+                    / old_artifact.category
+                    / old_artifact.title
+                )
+            ]
         call(shell_cmd)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Assuming an artifact with id = 0 the following command throws an UnboundedLocalError:
`kb update -x --id 0` 
The code fixes this and additionally changes -x from an option to a flag. 

Does this close any currently open issues?
------------------------------------------
Nope


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ or https://bpaste.net and insert the link here.)

Any other comments?
-------------------

Where has this been tested?
---------------------------

**Operating System:** Ubuntu

**Platform:** Linux

**Target Platform:** ...
