### PR TITLE
Need to persist the actual knowledge base directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,5 @@ services:
       dockerfile: ./docker/dockerfile
     volumes:
       - ./docker/data:/data
+      - ./docker/.kb:/root/.kb
     tty: true


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When running in a docker container, data is saved in /root/.kb.

When the container is stopped, and later restarted, /root/.kb no longer exists.

Does this close any currently open issues?
------------------------------------------
https://github.com/gnebbia/kb/issues/33

Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ or https://bpaste.net and insert the link here.)

Any other comments?
-------------------
...

Where has this been tested?
---------------------------

**Operating System:** ...

**Platform:** ...

**Target Platform:** ...
