### PR TITLE
Make list comprehensions simpler/easier to read.

### DIFF
--- a/kb/filesystem.py
+++ b/kb/filesystem.py
@@ -34,12 +34,11 @@ def list_files(directory: str) -> List[str]:
     in the directory
     """
 
-    # Get kbdir absolute path independently from OS
+    # Get kbdir path
     dirpath = Path(directory)
-    dirpathabs = str(Path(directory).absolute())
 
     # Get list of files in the form: file1, dir1/file2, ...
-    files = [str(f.absolute()).replace(dirpathabs, '')[1:]
+    files = [str(f.relative_to(dirpath))
              for f in dirpath.rglob("*") if f.is_file()]
     return files
 
@@ -55,12 +54,11 @@ def list_dirs(directory: str) -> List[str]:
     A list of strings representing the path of directories contained
     in the provided directory
     """
-    # Get kbdir absolute path independently from OS
+    # Get kbdir path
     dirpath = Path(directory)
-    dirpathabs = str(dirpath.absolute())
 
     # Get list of files in the form: file1, dir1/file2, ...
-    files = [str(f.absolute()).replace(dirpathabs, '')[1:]
+    files = [str(f.relative_to(dirpath))
              for f in dirpath.rglob("*") if f.is_dir()]
     return files
 


### PR DESCRIPTION
Make list comprehensions in list_files and list_dirs
from filesystem.py easier to read.

What does this implement/fix? Explain your changes.
---------------------------------------------------
I found the list comprehensions in `list_files` and `list_dirs` a little hard to read in `filesystem.py`. I've simplified them by using the `relative_to` method for `Path` objects.
