### PR TITLE
Corrected minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ kb template delete lisp-cheatsheets
 
 #### Edit a template
 
-To edit the template called "listp-cheatsheets" just do:
+To edit the template called "lisp-cheatsheets" just do:
 ```sh
 kb template edit lisp-cheatsheets
 ```


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
single letter typo in Templates portion - 

"listp-cheatsheet" should be "lisp-cheatsheet" - see diff

Does this close any currently open issues?
------------------------------------------
...


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ or https://bpaste.net and insert the link here.)

Any other comments?
-------------------
...

Where has this been tested?
---------------------------

**Operating System:** ...

**Platform:** ...

**Target Platform:** ...
