### PR TITLE
Fix gnebbia/kb#83

### DIFF
--- a/kb/filesystem.py
+++ b/kb/filesystem.py
@@ -235,12 +235,13 @@ def get_filename_parts_wo_prefix(
     Returns:
     The provided filename without the provided prefix
     """
-    filename_str = str(filename)
-    prefix_str = str(prefix_to_remove)
-    return tuple(filename_str.replace(prefix_str, '')
-                 .replace("/", " ")
-                 .replace("\\", " ")
-                 .strip().split())
+    prefix_path = Path(prefix_to_remove)
+    file_path = Path(filename)
+
+    try:
+        return file_path.relative_to(prefix_path).parts
+    except ValueError:
+        file_path.parts
 
 
 def grep_in_files(


### PR DESCRIPTION
Fix problem with spaces in artifact title when using grep command.

What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes the issue #83 of the grep command crashing with an IndexError when artifact titles contain spaces. If an artifact's title contains spaces [get_file_name_wo_prefix()](https://github.com/gnebbia/kb/blob/6a1e060dbd8cb0152950ae3f130c35a444c3cd2c/kb/filesystem.py#L240) parses the artifact title incorrectly. 

The following call to [db_get_artifacts_by_filter()](https://github.com/gnebbia/kb/blob/6a1e060dbd8cb0152950ae3f130c35a444c3cd2c/kb/commands/grep.py#L80) returns no results because all but the last parts of the title are incorporated into the category parameter. When the code tries to extract the (non-existen) result, an index error is raised.

A detailed description of the issue can be found [here](https://github.com/gnebbia/kb/issues/83#issuecomment-864437053)

The fix uses the standard library class [pathlib.Path](https://docs.python.org/3.6/library/pathlib.html#module-pathlib) for prefix removal and parsing of path components.

Does this close any currently open issues?
------------------------------------------
It is supposed to fix #83.


Any relevant logs, error output, etc?
-------------------------------------
...

Any other comments?
-------------------
...

Where has this been tested?
---------------------------

**Operating System:** linux, ubuntu 18.04

**Platform:** x86_64

**Target Platform:** x86_64/windows
