### PR TITLE
fixing homebrew sha mismatch error for v0.1.7, yw

### DIFF
--- a/HomebrewFormula/kb.rb
+++ b/HomebrewFormula/kb.rb
@@ -5,7 +5,7 @@ class Kb < Formula
   homepage "https://github.com/gnebbia/kb"
   url "https://github.com/gnebbia/kb.git",
     tag:      "v0.1.7",
-    revision: "40d361d420baab260e6a57a21f4908f1a8a283ee"
+    revision: "be3aceb291e7e58e0d17eb4ceeac3090353c917f"
   license "GPL-3.0-or-later"
 
   depends_on "python@3.8"


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixing homebrew install sha mismatch error.

Does this close any currently open issues?
------------------------------------------
n/a


Any relevant logs, error output, etc?
-------------------------------------
`==> Checking out tag v0.1.7
HEAD is now at be3aceb Preparation for release 0.1.7
HEAD is now at be3aceb Preparation for release 0.1.7
Error: v0.1.7 tag should be 40d361d420baab260e6a57a21f4908f1a8a283ee
but is actually be3aceb291e7e58e0d17eb4ceeac3090353c917f`

Any other comments?
-------------------
Welcome! Keep up the good work.

Where has this been tested?
---------------------------

**Operating System:** MAC

**Platform:** x86

**Target Platform:** Any
